### PR TITLE
docs: update README with project-specific content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,52 @@
-# Tina Starter 🦙
+# Church of Christ Jacksonville — Website
 
-![tina-nextjs-starter-demo](https://user-images.githubusercontent.com/103008/130587027-995ccc45-a852-4f90-b658-13e8e0517339.gif)
+The official website for the Church of Christ Jacksonville conference, built with **Next.js** and powered by **TinaCMS** for visual content editing.
 
-This Next.js starter is powered by [TinaCMS](https://app.tina.io) for you and your team to visually live edit the structured content of your website. ✨
+🔗 **Live site:** [website-cocj.vercel.app](https://website-cocj.vercel.app)
 
-The content is managed through Markdown and JSON files stored in your GitHub repository, and queried through Tina GraphQL API.
+## Tech Stack
 
-### Features
+- **Next.js** (TypeScript)
+- **TinaCMS** — headless CMS with Git-backed content (Markdown/JSON)
+- **Vercel** — hosting & deployment
+- **pnpm** — package manager
 
-- [Tina Headless CMS](https://app.tina.io) for authentication, content modeling, visual editing and team management.
-- [Vercel](https://vercel.com) deployment to visually edit your site from the `/admin` route.
-- Local development workflow from the filesystem with a local GraqhQL server.
+## Getting Started
 
-## Requirements
+### Prerequisites
 
-- Git, [Node.js Active LTS](https://nodejs.org/en/about/releases/), pnpm installed for local development.
-- A [TinaCMS](https://app.tina.io) account for live editing.
+- Node.js (see `.nvmrc` for version)
+- pnpm
 
-## Local Development
+### Install & Run
 
-Install the project's dependencies:
-
-> [!NOTE]  
-> [Do you know the best package manager for Node.js?](https://www.ssw.com.au/rules/best-package-manager-for-node/) Using the right package manager can greatly enhance your development workflow. We recommend using pnpm for its speed and efficient handling of dependencies. Learn more about why pnpm might be the best choice for your projects by checking out this rule from SSW.
-
-
-```
+```bash
 pnpm install
-```
-
-Run the project locally:
-
-```
 pnpm dev
 ```
 
-### Local URLs
+**Local URLs:**
 
-- http://localhost:3000 : browse the website
-- http://localhost:3000/admin : connect to Tina Cloud and go in edit mode
-- http://localhost:3000/exit-admin : log out of Tina Cloud
-- http://localhost:4001/altair/ : GraphQL playground to test queries and browse the API documentation
+- `http://localhost:3000` — site
+- `http://localhost:3000/admin` — CMS editor (requires TinaCMS account)
+- `http://localhost:4001/altair/` — GraphQL playground
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and fill in your TinaCMS credentials:
+
+```
+NEXT_PUBLIC_TINA_CLIENT_ID=<from app.tina.io>
+TINA_TOKEN=<from app.tina.io>
+NEXT_PUBLIC_TINA_BRANCH=<branch with Tina configured>
+```
 
 ## Deployment
 
-### GitHub Pages
+The site auto-deploys to **Vercel** on push to main.
 
-This starter can be deployed to GitHub Pages. A GitHub Actions workflow is included that handles the build and deployment process. 
+For **GitHub Pages** deployment, a workflow is included at `.github/workflows/build-and-deploy.yml`. Requires `NEXT_PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN` as repository secrets.
 
-To deploy to GitHub Pages:
+## License
 
-1. In your repository settings, ensure GitHub Pages is enabled and set to deploy from the `gh-pages` branch
-2. Push changes to your main branch - the workflow will automatically build and deploy the site
-
-> [!NOTE]
-> When deploying to GitHub Pages, you'll need to update your secrets in Settings | Secrets and variables | Actions to include:
-> - `NEXT_PUBLIC_TINA_CLIENT_ID`
-> - `TINA_TOKEN`
->
-> You get these from your TinaCloud project - [read the docs](https://tina.io/docs/tina-cloud/deployment-options/github-pages)
-
-> [!IMPORTANT]
-> GitHub Pages does not support server side code, so this will run as a static site. If you don't want to deploy to GitHub pages, just delete `.github/workflows/build-and-deploy.yml`
-
-### Building the Starter Locally (Using the hosted content API)
-
-Replace the `.env.example`, with `.env`
-
-```
-NEXT_PUBLIC_TINA_CLIENT_ID=<get this from the project you create at app.tina.io>
-TINA_TOKEN=<get this from the project you create at app.tina.io>
-NEXT_PUBLIC_TINA_BRANCH=<Specify the branch with Tina configured>
-```
-
-Build the project:
-
-```bash
-pnpm build
-```
-
-## Getting Help
-
-To get help with any TinaCMS challenges you may have:
-
-- Visit the [documentation](https://tina.io/docs/) to learn about Tina.
-- [Join our Discord](https://discord.gg/zumN63Ybpf) to share feedback.
-- Visit the [community forum](https://community.tinacms.org/) to ask questions.
-- Get support through the chat widget on the TinaCMS Dashboard
-- [Email us](mailto:support@tina.io) to schedule a call with our team and share more about your context and what you're trying to achieve.
-- [Search or open an issue](https://github.com/tinacms/tinacms/issues) if something is not working.
-- Reach out on Twitter at [@tina_cms](https://twitter.com/tina_cms).
-
-## Development tips
-
-### Visual Studio Code GraphQL extension
-
-[Install the GraphQL extension](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) to benefit from type auto-completion.
-
-### Typescript
-
-A good way to ensure your components match the shape of your data is to leverage the auto-generated TypeScript types.
-These are rebuilt when your `tina` config changes.
-
-## LICENSE
-
-Licensed under the [Apache 2.0 license](./LICENSE).
-
-
-# Repository cleaned of LFS content
-# Repository cleaned of LFS content - Wed Sep 17 15:00:42 AEST 2025
-
+[Apache 2.0](./LICENSE)


### PR DESCRIPTION
Replaces the default TinaCMS starter README with project-specific documentation for the Church of Christ Jacksonville website.

**Changes:**
- Added project name and description
- Link to live site
- Cleaned up tech stack, setup, and deployment sections
- Removed boilerplate TinaCMS marketing content